### PR TITLE
Fix multiple open tab listeners

### DIFF
--- a/safari/buffer.safariextension/data/main.js
+++ b/safari/buffer.safariextension/data/main.js
@@ -58,7 +58,6 @@ var attachOverlay = function (data, cb) {
             cb(overlayData);
         }, 0);
     });
-
     // Don't try to JSON encode a tab
     data.tab = null;
 
@@ -68,9 +67,6 @@ var attachOverlay = function (data, cb) {
 
     // Inform overlay that click has occurred
     port.emit("buffer_click", data);
-
-    // For the open popup fallback:
-    port.on('buffer_safari_open', openTab);
 };
 
 var openTab = function (url) {
@@ -78,6 +74,22 @@ var openTab = function (url) {
     var newTab = safari.application.activeBrowserWindow.openTab("foreground");
     newTab.url = url;
 };
+
+// For the open popup fallback:
+var attachPopupHandler = function(tab) {
+  tab.addEventListener('message', function (ev) {
+    if (ev.name === 'buffer_open_popup')
+      openTab(ev.message);
+  }, false);
+};
+
+safari.application.browserWindows.forEach(function(window) {
+  window.tabs.forEach(attachPopupHandler);
+});
+
+safari.application.addEventListener('open', function(e) {
+  attachPopupHandler(safari.application.activeBrowserWindow.activeTab);
+}, true);
 
 // Query for a specific tab by attribute and value
 //

--- a/safari/buffer.safariextension/data/safari/buffer-safari-port-wrapper.js
+++ b/safari/buffer.safariextension/data/safari/buffer-safari-port-wrapper.js
@@ -3,41 +3,42 @@
  * Firefox ports. The Safari API changes slightly depending on whether this
  * is loaded in a contentScript or not.
  *
- * port is either a safari tab object or the global safari.self object in 
+ * port is either a safari tab object or the global safari.self object in
  * content scripts
  */
 var PortWrapper = function (port, name) {
-    
-    var contentScript = false;
-    if( port.tab ) contentScript = true;
-    
-    return {
-        on: function (type, cb) {
-            //console.log(name, "listening for", type);
-            return port.addEventListener("message", function (ev) {
-                if( ev.name == type ) cb(ev.message);
-            }, false);
-        },
-        off: function (type, cb) {
-            port.removeEventListener(type, cb);
-        },
-        emit: function(type, payload) {
-            //console.log(name, "dispatching ", type, payload);
-            if( contentScript ) port.tab.dispatchMessage(type, payload);
-            else port.page.dispatchMessage(type, payload);
-        },
-        destroy: function () {
-            port = null;
-        },
-        name: port.name,
-        raw: port
-    };
-    
+
+  var contentScript = false;
+  if( port.tab ) contentScript = true;
+
+  return {
+    on: function (type, cb) {
+      //console.log(name, "listening for", type);
+      return port.addEventListener("message", function (ev) {
+        if( ev.name == type ) cb(ev.message);
+      }, false);
+    },
+    off: function (type, cb) {
+      // NOTE - this does not work
+      port.removeEventListener(type, cb);
+    },
+    emit: function(type, payload) {
+      //console.log(name, "dispatching ", type, payload);
+      if( contentScript ) port.tab.dispatchMessage(type, payload);
+      else port.page.dispatchMessage(type, payload);
+    },
+    destroy: function () {
+      port = null;
+    },
+    name: port.name,
+    raw: port
+  };
+
 };
 
 if( !xt ) var xt = {};
 xt.port = {
-    on: function () {console.log("port.on called before initialised.", arguments)},
-    off: function () {console.log("port.off called before initialised.", arguments)},
-    emit: function () {console.log("port.emit called before initialised.", arguments)}
+  on: function () {console.log("port.on called before initialised.", arguments)},
+  off: function () {console.log("port.off called before initialised.", arguments)},
+  emit: function () {console.log("port.emit called before initialised.", arguments)}
 };


### PR DESCRIPTION
The original listener in the `attachOverlay` function was causing multiple tabs to open. 
